### PR TITLE
Implementing real binary numbering

### DIFF
--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -62,6 +62,13 @@ class RCSwitch {
     void switchOff(char* sGroup, int nSwitchNumber);
     void switchOn(char sFamily, int nGroup, int nDevice);
     void switchOff(char sFamily, int nGroup, int nDevice);
+    /**
+     * new methods, that use binary representation of
+     * socket numbering instead of the old represenation
+     * by switching each a differend switch on.
+     */
+    void switchOnBinary(char* sGroup, int nSwitchNumber);
+    void switchOffBinary(char* sGroup, int nSwitchNumber);
 
     void sendTriState(char* Code);
     void send(unsigned long Code, unsigned int length);
@@ -90,6 +97,7 @@ class RCSwitch {
   private:
     char* getCodeWordB(int nGroupNumber, int nSwitchNumber, boolean bStatus);
     char* getCodeWordA(char* sGroup, int nSwitchNumber, boolean bStatus);
+    char* getCodeWordD(char* sGroup, int nSwitchNumber, boolean bStatus);
     char* getCodeWordC(char sFamily, int nGroup, int nDevice, boolean bStatus);
     void sendT0();
     void sendT1();

--- a/README.md
+++ b/README.md
@@ -22,8 +22,14 @@ This project includes a web interface.
 
 ## Usage
 Try if all is working with the send program
-*  Switch on single socket: ./send.cpp 00001 1 1
+*  Switch on single socket: `./send.cpp 00001 1 1`
 
+Pass the `-b`-option to use binary socket numbering instead of the common "only one switch up"-numbering. See [Binary Mode](Binary Mode) for further details.
+
+## Binary Mode
+
+
+## Daemon
 Use the daemon in combination with the webinterface
 * Copy the files in webinterface in your http directory
 * Edit ip address in config.php

--- a/README.md
+++ b/README.md
@@ -27,8 +27,31 @@ Try if all is working with the send program
 Pass the `-b`-option to use binary socket numbering instead of the common "only one switch up"-numbering. See [Binary Mode](#binary-mode) for further details.
 
 ## Binary Mode
+Most sockets available for purchase use the following numbering scheme:
 
+no. | address
+--- | -------
+  A |   10000
+  B |   01000
+  C |   00100
+  D |   00010
+  E |   00001
+  
+Of course, this doesn't make much sense, because it limits the maximum of supported sockets to 5 (or 6, if 00000 is included), and is less intuitive. Using real binary numbering would increase the limit of supported sockets per system to 31, and be more intutive. In binary mode, the sockets need to be numbered as below:
 
+no. | address
+--- | -------
+  1 |   00001
+  2 |   00010
+  3 |   00011
+  4 |   00100
+  5 |   00101
+  8 |   01000
+ 16 |   10000
+ 31 |   11111
+ 
+Note that you need to configure your sockets to this kind of numbering to use this feature. This often includes that the dedicated remote that gets shipped with the sockets often is rendered useless, since it only supports the former way of numbering.
+  
 ## Daemon
 Use the daemon in combination with the webinterface
 * Copy the files in webinterface in your http directory

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project includes a web interface.
 Try if all is working with the send program
 *  Switch on single socket: `./send.cpp 00001 1 1`
 
-Pass the `-b`-option to use binary socket numbering instead of the common "only one switch up"-numbering. See [Binary Mode](#Binary Mode) for further details.
+Pass the `-b`-option to use binary socket numbering instead of the common "only one switch up"-numbering. See [Binary Mode](#Binary-Mode) for further details.
 
 ## Binary Mode
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project includes a web interface.
 Try if all is working with the send program
 *  Switch on single socket: `./send.cpp 00001 1 1`
 
-Pass the `-b`-option to use binary socket numbering instead of the common "only one switch up"-numbering. See [Binary Mode](#Binary-Mode) for further details.
+Pass the `-b`-option to use binary socket numbering instead of the common "only one switch up"-numbering. See [Binary Mode](#binary-mode) for further details.
 
 ## Binary Mode
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project includes a web interface.
 Try if all is working with the send program
 *  Switch on single socket: `./send.cpp 00001 1 1`
 
-Pass the `-b`-option to use binary socket numbering instead of the common "only one switch up"-numbering. See [Binary Mode](Binary Mode) for further details.
+Pass the `-b`-option to use binary socket numbering instead of the common "only one switch up"-numbering. See [Binary Mode](#Binary Mode) for further details.
 
 ## Binary Mode
 

--- a/send.cpp
+++ b/send.cpp
@@ -6,18 +6,39 @@
 #include "RCSwitch.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <string>
+//#include <iostream>
 
 int main(int argc, char *argv[]) {
-
-  /*
+  /**
    * output PIN is hardcoded for testing purposes
    * see https://projects.drogon.net/raspberry-pi/wiringpi/pins/
    * for pin mapping of the raspberry pi GPIO connector
    */
   int PIN = 0;
-  char* systemCode = argv[1];
-  int unitCode = atoi(argv[2]);
-  int command  = atoi(argv[3]);
+  /**
+   * using old numbering mode by default,
+   * see RCSwitch.cpp for differences
+   */
+  bool binaryMode = false;
+  char* systemCode;
+  int unitCode;
+  int command;
+  std::string firstArgument = argv[1];
+
+  if (firstArgument == "-b") {
+    printf("operating in binary mode...\n");
+    binaryMode = true;
+    //position of data in input is now shifted by 1 because of '-b'-flag
+    systemCode = argv[2];
+    unitCode = atoi(argv[3]);
+    command  = atoi(argv[4]);
+  } else {
+    //no binary mode, therefore using normal mode with old numbering
+    systemCode = argv[1];
+    unitCode = atoi(argv[2]);
+    command  = atoi(argv[3]);
+  }
 
   if (wiringPiSetup () == -1) return 1;
   piHiPri(20);
@@ -26,24 +47,39 @@ int main(int argc, char *argv[]) {
   mySwitch.setPulseLength(300);
   mySwitch.enableTransmit(PIN);
 
-  switch(command) {
-    case 1:
-      mySwitch.switchOn(systemCode, unitCode);
-      break;
-    case 0:
-      mySwitch.switchOff(systemCode, unitCode);
-      break;
-    case 2:
-      // 00001 2 on binary coded
-      mySwitch.send("010101010001000101010001");
-      break;
-    case 3:
-      // 00001 2 on as TriState
-      mySwitch.sendTriState("FFFF0F0FFF0F");
-      break;
-    default:
-      printf("command[%i] is unsupported\n", command);
-      return -1;
+  if (binaryMode) {
+    switch (command){
+      case 1:
+        mySwitch.switchOnBinary(systemCode, unitCode);
+        break;
+      case 0:
+        mySwitch.switchOffBinary(systemCode, unitCode);
+        break;
+      default:
+        printf("command[%i] is unsupported\n", command);
+        return -1;
+    }
+    return 0;
+  } else {
+    switch(command) {
+      case 1:
+        mySwitch.switchOn(systemCode, unitCode);
+        break;
+      case 0:
+        mySwitch.switchOff(systemCode, unitCode);
+        break;
+      case 2:
+        // 00001 2 on binary coded
+        mySwitch.send("010101010001000101010001");
+        break;
+      case 3:
+        // 00001 2 on as TriState
+        mySwitch.sendTriState("FFFF0F0FFF0F");
+        break;
+      default:
+        printf("command[%i] is unsupported\n", command);
+        return -1;
+    }
+    return 0;
   }
-  return 0;
 }

--- a/send.cpp
+++ b/send.cpp
@@ -9,6 +9,17 @@
 #include <string>
 //#include <iostream>
 
+void printUsage(){
+  printf("This is rasperry remote, an application to control remote plugs with the Raspberry Pi.\n");
+  printf("Based on RCSwitch and wiringPi. See github.com/xkonni/raspberry-remote for further reference.\n");
+  printf("Usage: \n sudo send [-b] <systemCode> <unitCode> <command> or:\n sudo send -h\n");
+  printf("Where the -b argument switches the instance to binary mode, and the -h option displays this help.\n\n");
+  printf("Binary mode means, that instead numbering the sockets by 00001 00010 00100 01000 10000, the sockets\n");
+  printf("are numbered in real binary numbers as following: 00001 00010 00011 00100 00101 00110 and so on.\n");
+  printf("This means that your sockets need to be setup in this manner, which often includes that the dedicated remote\n");
+  printf("is rendered useless, but more than 6 sockets are supported.\n");
+}
+
 int main(int argc, char *argv[]) {
   /**
    * output PIN is hardcoded for testing purposes
@@ -24,15 +35,55 @@ int main(int argc, char *argv[]) {
   char* systemCode;
   int unitCode;
   int command;
+
+  if (argc < 4) {
+    /**
+     * no matter, which mode is used, at least 4 arguments are required:
+     * 0: command name (send)
+     * 1: systemCode
+     * 2: unitCode
+     * 3: command
+     * if there are less arguments, the help should be printed
+     * and the application should terminate.
+     */
+    printUsage();
+    return 1;
+  }
+
+  /**
+   * This needs to stand after the check of how many arguments are passed,
+   * because if there is only 1 argument passed, argv[1] is NULL, which
+   * will result in an error, because a std::string can't be constructed
+   * by a NULL value. Therefore it is important to terminate the application
+   * if there are less than 2 arguments (in this case: less than 4 arguments)
+   * passed.
+   */
   std::string firstArgument = argv[1];
 
-  if (firstArgument == "-b") {
+  if (firstArgument == "-b" or firstArgument == "--binary") {
+    if (argc < 5) {
+    /**
+     * in binaryMode, 5 arguments are required:
+     * 0: command name ('send')
+     * 1: binary operator ('-b')
+     * 2: systemCode
+     * 3: unitCode
+     * 4: command
+     * if there are less arguments, the help should be printed,
+     * and the application should terminate.
+     */
+      printUsage();
+      return 1;
+    }
+
     printf("operating in binary mode...\n");
     binaryMode = true;
     //position of data in input is now shifted by 1 because of '-b'-flag
     systemCode = argv[2];
     unitCode = atoi(argv[3]);
     command  = atoi(argv[4]);
+  } else if (firstArgument == "-h" or firstArgument == "--help" or firstArgument == "-?") {
+    printUsage();
   } else {
     //no binary mode, therefore using normal mode with old numbering
     systemCode = argv[1];
@@ -57,6 +108,7 @@ int main(int argc, char *argv[]) {
         break;
       default:
         printf("command[%i] is unsupported\n", command);
+        printUsage();
         return -1;
     }
     return 0;
@@ -78,6 +130,7 @@ int main(int argc, char *argv[]) {
         break;
       default:
         printf("command[%i] is unsupported\n", command);
+        printUsage();
         return -1;
     }
     return 0;


### PR DESCRIPTION
Adding a fourth codeword-generation-method which adresses the sockets in real binary format instead of using the deprecated numbering method 10000, 01000, 00100... for numbering the sockets, as provided by most manufacturers. This method may be used by passing the `send`-binary the `-b`-flag, it is implemented as a getCodeWordD-method in RCSwitch.cpp. I documented my changes as well in the source code as in the README.md.

Furthermore, I have added a help text to the send-binary, which is printed to stdout when a) not enough arguments are passed or b) the `-h` or `--help`-argument is passed.

Feel free to comment ;)