### PR TITLE
replaced include by require, added exit() after header(), replaced so…

### DIFF
--- a/webinterface/config.php
+++ b/webinterface/config.php
@@ -10,7 +10,6 @@
 /*
  * define ip address and port here
  */
-$source = $_SERVER['SERVER_ADDR'];
 $target = '192.168.11.124';
 $port = 11337;
 


### PR DESCRIPTION
I am running webinterface/webserver on the same machine as my proxy so $_SERVER['SERVER_ADDR'] returns 127.0.0.1 as own address which makes it impossible to connect to a remote RaspberryPI.
To get rid of configuring any source address (setting $source to lan ip would "fix" this issue) I replaced socket stuff by fsockopen().

I've also added an exit() after header() (which is the right way) and changed include() of the config to require (without config it does not make any sense).